### PR TITLE
Found this strange behaviour in the RequestProcessor library

### DIFF
--- a/src/RequestProcessor/Models/HeadersInput.cs
+++ b/src/RequestProcessor/Models/HeadersInput.cs
@@ -10,23 +10,23 @@ namespace RequestProcessor.Models
     {
         [Required]
         [FromHeader(Name = Constants.XSentByHeaderName)]
-        public string XSentBy { get; set; }
+        public string? XSentBy { get; set; }
 
         [Required]
         [FromHeader(Name = Constants.XSendToHeaderName)]
-        public string XSendTo { get; set; }
+        public string? XSendTo { get; set; }
 
         [Required]
         [FromHeader(Name = Constants.XMessageIdHeaderName)]
-        public string XMessageId { get; set; }
+        public string? XMessageId { get; set; }
 
         [FromHeader(Name = Constants.XMessageIdRefHeaderName)]
-        public string XMessageIdRef { get; set; }
+        public string? XMessageIdRef { get; set; }
 
         [FromHeader(Name = Constants.XModelTypeHeaderName)]
-        public string XModelType { get; set; }
+        public string? XModelType { get; set; }
 
         [FromHeader(Name = Constants.ContentTypeHeaderName)]
-        public string ContentType { get; set; }
+        public string? ContentType { get; set; }
     }
 }

--- a/src/RequestProcessor/Models/Message.cs
+++ b/src/RequestProcessor/Models/Message.cs
@@ -6,7 +6,7 @@ namespace RequestProcessor.Models
     [ExcludeFromCodeCoverage]
     public class Message
     {
-        public string Payload { get; set; }
-        public HeadersInput Headers { get; set; }
+        public string? Payload { get; set; }
+        public HeadersInput? Headers { get; set; }
     }
 }


### PR DESCRIPTION
Found that the model binder was treating unspecified not-nullable properties as [Required]